### PR TITLE
Missed "@mate-academy/scripts" dependency added to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "typescript": "^4.3.5"
   },
   "devDependencies": {
+    "@mate-academy/scripts": "^0.9.2",
     "@mate-academy/eslint-config": "*",
     "@typescript-eslint/eslint-plugin": "^4.29.0",
     "@typescript-eslint/parser": "^4.29.0",


### PR DESCRIPTION
Students have a problem with dependencies installing because of missed `"@mate-academy/scripts"` dependency in `devDependencies` in `package.json` file. In this PR this missing dependency added