### PR TITLE
implement groupByKey function with TypeScript types

### DIFF
--- a/src/groupByKey.ts
+++ b/src/groupByKey.ts
@@ -2,6 +2,19 @@ type GroupsMap<T> = {
   [key: string]: T[];
 };
 
-export function groupByKey(items, key) {
-  // write code here;
+export function groupByKey<T extends Record<string, unknown>>(
+  items: T[],
+  key: keyof T,
+): GroupsMap<T> {
+  return items.reduce((groups: GroupsMap<T>, item: T) => {
+    const groupKey = String(item[key]);
+
+    if (!groups[groupKey]) {
+      groups[groupKey] = [];
+    }
+
+    groups[groupKey].push(item);
+
+    return groups;
+  }, {});
 }


### PR DESCRIPTION
The function takes an array of objects and a key, then returns an object
where items are grouped by the value of that key.

- Used generics: `T extends Record<string, unknown>` and `key: keyof T`
  for full type safety
- Used `reduce` to build the result object
- All 7 tests pass